### PR TITLE
Add plop-pack-npm-install-packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Because of it's powerful extendability, you can make your own packages that tie 
 
 - [Plop Pack Git Init](https://github.com/crutchcorn/plop-pack-git-init) - A plop helper that provides a git init action for CLI purposes
 - [Plop Pack NPM Install](https://github.com/crutchcorn/plop-pack-npm-install) - A plop helper that provides an npm install action for CLI purposes
+- [Plop Pack NPM Install Packages](https://github.com/piersolenski/plop-pack-npm-install-packages) - A plop action to install packages with NPM
 - [Plop Pack Azure NPM](https://github.com/crutchcorn/plop-pack-azure-npm) - A plop helper that provides a setup for Azure NPM NPMRC files
 - [Plop Action Copy](https://github.com/bradgarropy/plop-action-copy) - A plop action to copy files.
 

--- a/data.json
+++ b/data.json
@@ -10,6 +10,11 @@
 		"category": "Actions"
 	},
 	{
+		"name": "Plop Pack NPM Install Packages",
+		"repoUrl": "piersolenski/plop-pack-npm-install-packages",
+		"category": "Actions"
+	},
+	{
 		"name": "Plop Pack Azure NPM",
 		"repoUrl": "crutchcorn/plop-pack-azure-npm",
 		"category": "Actions"


### PR DESCRIPTION
Appreciate it's similarly named to `plop-pack-npm-install` however I have commented on the distinction in the [README](https://github.com/piersolenski/plop-pack-npm-install-packages#usage) 😊