### PR TITLE
Add Plop Pack Remove to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Because of it's powerful extendability, you can make your own packages that tie 
 - [Plop Pack NPM Install Packages](https://github.com/piersolenski/plop-pack-npm-install-packages) - A plop action to install packages with NPM
 - [Plop Pack Azure NPM](https://github.com/crutchcorn/plop-pack-azure-npm) - A plop helper that provides a setup for Azure NPM NPMRC files
 - [Plop Action Copy](https://github.com/bradgarropy/plop-action-copy) - A plop action to copy files.
+- [Plop Pack Remove](https://github.com/TheSharpieOne/plop-pack-remove) - Plop actions that provides the ability to remove individual and globs of files
 
 ## Helpers
 

--- a/data.json
+++ b/data.json
@@ -25,6 +25,11 @@
 		"category": "Actions"
 	},
 	{
+		"name": "Plop Pack Remove",
+		"repoUrl": "TheSharpieOne/plop-pack-remove",
+		"category": "Actions"
+	},
+	{
 		"name": "Plop Helper Date",
 		"repoUrl": "bradgarropy/plop-helper-date",
 		"category": "Helpers"


### PR DESCRIPTION
Add Plop Pack Remove to the README.

Plop Pack Remove is plop actions to remove a single file (with validation that the file existed in the first place) as well as multiple files/directories with a glob pattern.

See plopjs/plop#223