### PR TITLE
Add jasny/plop-jetbrains-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Because of its powerful extendability, you can make your own packages that tie i
 ## IDE Plugins
 
 - [Plop File Templates for Visual Studio Code](https://github.com/SamKirkland/plop-templates) - VSCode extension for plop.js file templates
+- [Plop Plugin for JetBrains IDEs](https://github.com/jasny/plop-jetbrains-plugin) - Run Plop code generators right from your IDE
 
 ## Inquirer Prompts
 
@@ -42,10 +43,13 @@ Because of its powerful extendability, you can make your own packages that tie i
 
 [![An inquirer prompt asking what directory you'd like to perform an action in. It has the ability to go up and down directories in the CLI](https://asciinema.org/a/31651.png)](https://asciinema.org/a/31651)
 
+
 - [Inquirer Recursive](https://github.com/nathanloisel/inquirer-recursive) - Recursive prompt for inquirer
 
 ![An inquirer prompt that loops through the same questions repeatedly until an exit condition is given](http://i.giphy.com/l2JhntGGk3QjTUIiA.gif)
 
+
 - [Inquirer Select Line](https://github.com/adam-golab/inquirer-select-line) - Prompt for inquirer for inserting into array
 
 ![An inquirer prompt showing the user moving up and down a list with arrow keys, placing an item in the list order](http://i.giphy.com/xUA7b1MxpngddUvdHW.gif)
+

--- a/data.json
+++ b/data.json
@@ -80,6 +80,11 @@
         "category": "IDE Plugins"
     },
     {
+        "name": "Plop Plugin for JetBrains IDEs",
+        "repoUrl": "jasny/plop-jetbrains-plugin",
+        "category": "IDE Plugins"
+    },
+    {
         "name": "Plop Generator React Atomic Component",
         "repoUrl": "ahoendgen/plop-generator-react-atomic-component",
         "category": "Generators"


### PR DESCRIPTION
I've created a Plop plugin for JetBrains IDEs (eg WebStorm). It determines the generators from the plopfile and shows a dialog based on the generator prompt.

See https://plugins.jetbrains.com/plugin/29277-plop

<img width="1280" height="800" alt="Screenshot from 2025-12-05 15-14-16" src="https://github.com/user-attachments/assets/71e68cf2-0e77-44dd-b00c-b851d4f9b1b3" />
<img width="1280" height="800" alt="Screenshot from 2025-12-05 15-15-07" src="https://github.com/user-attachments/assets/a6fa47ab-a6ee-4f47-9d0e-efb329f91182" />
